### PR TITLE
Update to Linux-PAM 1.5.3 with patch 1.5.2~2ubuntu1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,8 @@ check_c_source_compiles("
 #check pwn
 include(CheckSymbolExists)
 check_symbol_exists(getpwnam_r "pwd.h" HAVE_GETPWNAM_R)
+check_symbol_exists(explicit_bzero "string.h" HAVE_EXPLICIT_BZERO)
+check_symbol_exists(memset_explicit "string.h" HAVE_MEMSET_EXPLICIT)
 
 configure_file(config.h.in config.h)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})

--- a/config.h.in
+++ b/config.h.in
@@ -3,6 +3,8 @@
 #define CONFIG_H_AUTOGEN
 #cmakedefine HAVE_ATTRIBUTE_UNUSED
 #cmakedefine HAVE_GETPWNAM_R
+#cmakedefine HAVE_EXPLICIT_BZERO
+#cmakedefine HAVE_MEMSET_EXPLICIT
 
 #ifdef  HAVE_ATTRIBUTE_UNUSED
 #define UNUSED __attribute__((unused))

--- a/include/_pam_macros.h
+++ b/include/_pam_macros.h
@@ -7,6 +7,8 @@
  * Organized by Cristian Gafton <gafton@redhat.com>
  */
 
+#include "_porting.h"
+
 /* a 'safe' version of strdup */
 
 #include <stdlib.h>
@@ -14,20 +16,22 @@
 
 #define  x_strdup(s)  ( (s) ? strdup(s):NULL )
 
-/* Good policy to strike out passwords with some characters not just
-   free the memory */
+/*
+ * WARNING: Do NOT use these overwrite macros, as they do not reliable
+ * override the memory.
+ */
 
-#define _pam_overwrite(x)        \
-do {                             \
-     register char *__xx__;      \
-     if ((__xx__=(x)))           \
-          while (*__xx__)        \
-               *__xx__++ = '\0'; \
+#define _pam_overwrite(x)                  \
+do {                                       \
+     PAM_DEPRECATED register char *__xx__; \
+     if ((__xx__=(x)))                     \
+          while (*__xx__)                  \
+               *__xx__++ = '\0';           \
 } while (0)
 
 #define _pam_overwrite_n(x,n)   \
 do {                             \
-     register char *__xx__;      \
+     PAM_DEPRECATED register char *__xx__; \
      register unsigned int __i__ = 0;    \
      if ((__xx__=(x)))           \
         for (;__i__<n; __i__++) \
@@ -46,9 +50,13 @@ do {                 \
     }                \
 } while (0)
 
+/*
+ * WARNING: Do NOT use this macro, as it does not reliable override the memory.
+ */
+
 #define _pam_drop_reply(/* struct pam_response * */ reply, /* int */ replies) \
 do {                                              \
-    int reply_i;                                  \
+    PAM_DEPRECATED int reply_i;                   \
                                                   \
     for (reply_i=0; reply_i<replies; ++reply_i) { \
 	if (reply[reply_i].resp) {                \

--- a/include/_porting.h
+++ b/include/_porting.h
@@ -9,11 +9,19 @@
 #ifndef _PORTING_H
 #define _PORTING_H
 
+/* -------------- Special defines used by Linux-PAM -------------- */
+
 #if defined(__GNUC__) && defined(__GNUC_MINOR__)
 # define PAM_GNUC_PREREQ(maj, min) \
         ((__GNUC__ << 16) + __GNUC_MINOR__ >= ((maj) << 16) + (min))
 #else
 # define PAM_GNUC_PREREQ(maj, min) 0
+#endif
+
+#if PAM_GNUC_PREREQ(3,1)
+# define PAM_DEPRECATED __attribute__((__deprecated__))
+#else
+# define PAM_DEPRECATED
 #endif
 
 /* ... adapted from the pam_appl.h file created by Theodore Ts'o and

--- a/include/pam_cc_compat.h
+++ b/include/pam_cc_compat.h
@@ -6,6 +6,8 @@
 #define PAM_CC_COMPAT_H
 #include "_porting.h"
 
+#include "config.h"
+
 #if defined __clang__ && defined __clang_major__ && defined __clang_minor__
 # define PAM_CLANG_PREREQ(maj, min)					\
 	((__clang_major__ << 16) + __clang_minor__ >= ((maj) << 16) + (min))
@@ -31,6 +33,11 @@
 	_Pragma("GCC diagnostic ignored \"-Wcast-align\"")
 # define DIAG_POP_IGNORE_CAST_ALIGN					\
 	_Pragma("GCC diagnostic pop")
+# define DIAG_PUSH_IGNORE_FORMAT_NONLITERAL				\
+	_Pragma("GCC diagnostic push");					\
+	_Pragma("GCC diagnostic ignored \"-Wformat-nonliteral\"")
+# define DIAG_POP_IGNORE_FORMAT_NONLITERAL				\
+	_Pragma("GCC diagnostic pop")
 #elif PAM_CLANG_PREREQ(2, 6)
 # define DIAG_PUSH_IGNORE_CAST_QUAL					\
 	_Pragma("clang diagnostic push");				\
@@ -42,11 +49,18 @@
 	_Pragma("clang diagnostic ignored \"-Wcast-align\"")
 # define DIAG_POP_IGNORE_CAST_ALIGN					\
 	_Pragma("clang diagnostic pop")
+# define DIAG_PUSH_IGNORE_FORMAT_NONLITERAL				\
+	_Pragma("clang diagnostic push");				\
+	_Pragma("clang diagnostic ignored \"-Wformat-nonliteral\"")
+# define DIAG_POP_IGNORE_FORMAT_NONLITERAL				\
+	_Pragma("clang diagnostic pop")
 #else
-# define DIAG_PUSH_IGNORE_CAST_QUAL	/* empty */
-# define DIAG_POP_IGNORE_CAST_QUAL	/* empty */
-# define DIAG_PUSH_IGNORE_CAST_ALIGN	/* empty */
-# define DIAG_POP_IGNORE_CAST_ALIGN	/* empty */
+# define DIAG_PUSH_IGNORE_CAST_QUAL		/* empty */
+# define DIAG_POP_IGNORE_CAST_QUAL		/* empty */
+# define DIAG_PUSH_IGNORE_CAST_ALIGN		/* empty */
+# define DIAG_POP_IGNORE_CAST_ALIGN		/* empty */
+# define DIAG_PUSH_IGNORE_FORMAT_NONLITERAL	/* empty */
+# define DIAG_POP_IGNORE_FORMAT_NONLITERAL	/* empty */
 #endif
 
 /*
@@ -62,4 +76,4 @@
 # define PAM_IS_SAME_TYPE(x_, y_)	0
 #endif
 
-#endif //PAM_CC_COMPAT_H
+#endif /* PAM_CC_COMPAT_H */

--- a/include/pam_inline.h
+++ b/include/pam_inline.h
@@ -161,7 +161,7 @@ pam_read_passwords(int fd, int npass, char **passwords)
 				if (npass > 0) {
 					memcpy(passwords[i], pptr, rbytes);
 				}
-				memset(pptr, '\0', rbytes);
+				pam_overwrite_n(pptr, rbytes);
 			}
 		}
 		offset += rbytes;
@@ -169,7 +169,7 @@ pam_read_passwords(int fd, int npass, char **passwords)
 
 	/* clear up */
 	if (offset > 0 && npass > 0) {
-		memset(passwords[i], '\0', offset);
+		pam_overwrite_n(passwords[i], offset);
 	}
 
 	return i;

--- a/include/pam_modutil.h
+++ b/include/pam_modutil.h
@@ -102,7 +102,16 @@ pam_modutil_sanitize_helper_fds(pam_handle_t *pamh,
 				enum pam_modutil_redirect_fd redirect_stdout,
 				enum pam_modutil_redirect_fd redirect_stderr);
 
-/* lookup a value for key in login.defs file or similar key value format */
+/**************************************************
+ * @brief Lookup a value for the key in the file (i.e. login.defs or a similar
+ * key-value format file).
+ *
+ * @param[in] pamh The pam handle structure
+ * @param[in] file_name Configuration file name
+ * @param[in] key Lookup key
+ *
+ * @return value, or NULL if key was not found.
+ **************************************************/
 extern char * PAM_NONNULL((1,2,3))
 pam_modutil_search_key(pam_handle_t *pamh,
 		       const char *file_name,

--- a/man/custom-man.xsl
+++ b/man/custom-man.xsl
@@ -1,6 +1,6 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ss="http://docbook.sf.net/xmlns/string.subst/1.0" version="1.0">
-  <xsl:import href="http://docbook.sourceforge.net/release/xsl/current/manpages/profile-docbook.xsl"/>
+  <xsl:import href="http://docbook.sourceforge.net/release/xsl-ns/current/manpages/profile-docbook.xsl"/>
   <xsl:param name="vendordir"/>
 
   <xsl:param name="man.string.subst.map.local.pre">

--- a/man/pam_motd.8
+++ b/man/pam_motd.8
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: pam_motd
 .\"    Author: [see the "AUTHOR" section]
-.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 05/22/2022
+.\" Generator: DocBook XSL Stylesheets v1.79.2 <http://docbook.sf.net/>
+.\"      Date: 06/11/2023
 .\"    Manual: pam_motd Manual
-.\"    Source: pam_motd Manual
+.\"    Source: pam_motd
 .\"  Language: English
 .\"
-.TH "PAM_MOTD" "8" "05/22/2022" "pam_motd Manual" "pam_motd Manual"
+.TH "PAM_MOTD" "8" "06/11/2023" "pam_motd" "pam_motd Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -93,7 +93,7 @@ The
 environment variable is set after showing the motd files, even when all of them were silenced using symbolic links\&.
 .SH "OPTIONS"
 .PP
-\fBmotd=\fR\fB\fI/path/filename\fR\fR
+motd=/path/filename
 .RS 4
 The
 /path/filename
@@ -101,7 +101,7 @@ file is displayed as message of the day\&. Multiple paths to try can be specifie
 /etc/motd:/var/run/motd:/usr/lib/motd\&.
 .RE
 .PP
-\fBmotd_dir=\fR\fB\fI/path/dirname\&.d\fR\fR
+motd_dir=/path/dirname\&.d
 .RS 4
 The
 /path/dirname\&.d
@@ -109,7 +109,7 @@ directory is scanned and each file contained inside of it is displayed\&. Multip
 /etc/motd\&.d:/run/motd\&.d:/usr/lib/motd\&.d\&.
 .RE
 .PP
-\fBnoupdate\fR
+noupdate
 .RS 4
 Don\*(Aqt run the scripts in
 /etc/update\-motd\&.d

--- a/man/pam_motd.8.xml
+++ b/man/pam_motd.8.xml
@@ -1,27 +1,24 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_motd">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_motd">
 
   <refmeta>
     <refentrytitle>pam_motd</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">pam_motd Manual</refmiscinfo>
+    <refmiscinfo class="source">pam_motd</refmiscinfo>
+    <refmiscinfo class="manual">pam_motd Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_motd-name">
+  <refnamediv xml:id="pam_motd-name">
     <refname>pam_motd</refname>
     <refpurpose>Display the motd file</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_motd-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_motd-cmdsynopsis" sepchar=" ">
       <command>pam_motd.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         motd=<replaceable>/path/filename</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         motd_dir=<replaceable>/path/dirname.d</replaceable>
       </arg>
       <arg choice="opt">
@@ -30,7 +27,7 @@
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_motd-description">
+  <refsect1 xml:id="pam_motd-description">
 
     <title>DESCRIPTION</title>
 
@@ -41,7 +38,7 @@
       following locations:
     </para>
     <para>
-      <simplelist type='vert'>
+      <simplelist type="vert">
         <member><filename>/etc/motd</filename></member>
         <member><filename>/var/run/motd</filename></member>
         <member><filename>/usr/local/lib/motd</filename></member>
@@ -82,19 +79,19 @@
       <command>ln -s /dev/null /etc/motd.d/my_motd</command>
     </para>
     <para>
-      The <emphasis remap='B'>MOTD_SHOWN=pam</emphasis> environment variable
+      The <emphasis remap="B">MOTD_SHOWN=pam</emphasis> environment variable
       is set after showing the motd files, even when all of them were silenced
       using symbolic links.
     </para>
   </refsect1>
 
-  <refsect1 id="pam_motd-options">
+  <refsect1 xml:id="pam_motd-options">
 
     <title>OPTIONS</title>
     <variablelist>
       <varlistentry>
         <term>
-          <option>motd=<replaceable>/path/filename</replaceable></option>
+          motd=/path/filename
         </term>
         <listitem>
           <para>
@@ -107,7 +104,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>motd_dir=<replaceable>/path/dirname.d</replaceable></option>
+          motd_dir=/path/dirname.d
         </term>
         <listitem>
           <para>
@@ -120,7 +117,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>noupdate</option>
+          noupdate
         </term>
         <listitem>
           <para>
@@ -137,14 +134,14 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_motd-types">
+  <refsect1 xml:id="pam_motd-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       Only the <option>session</option> module type is provided.
     </para>
   </refsect1>
 
-  <refsect1 id='pam_motd-return_values'>
+  <refsect1 xml:id="pam_motd-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -174,7 +171,7 @@
     </variablelist>
      </refsect1>
 
-  <refsect1 id='pam_motd-examples'>
+  <refsect1 xml:id="pam_motd-examples">
     <title>EXAMPLES</title>
     <para>
       The suggested usage for <filename>/etc/pam.d/login</filename> is:
@@ -197,7 +194,7 @@ session  optional  pam_motd.so motd=/elsewhere/motd motd_dir=/elsewhere/motd.d
     </para>
   </refsect1>
 
-  <refsect1 id='pam_motd-see_also'>
+  <refsect1 xml:id="pam_motd-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -218,7 +215,7 @@ session  optional  pam_motd.so motd=/elsewhere/motd motd_dir=/elsewhere/motd.d
     </para>
   </refsect1>
 
-  <refsect1 id='pam_motd-author'>
+  <refsect1 xml:id="pam_motd-author">
     <title>AUTHOR</title>
       <para>
         pam_motd was written by Ben Collins &lt;bcollins@debian.org&gt;.


### PR DESCRIPTION
Update to Linux-PAM 1.5.3 with pacth 1.5.2~2ubuntu1

Related noteworthy changes in Linux-PAM 1.5.3 from upstream ([release note](https://github.com/linux-pam/linux-pam/releases/tag/v1.5.3)):
* Deprecated pam_lastlog: this module is no longer built by default because
it uses utmp, wtmp, btmp and lastlog, but none of them are Y2038 safe,
even on 64bit architectures.
* pam_lastlog will be removed in one of the next releases, consider using
pam_lastlog2 (from https://github.com/thkukuk/lastlog2) and/or
pam_wtmpdb (from https://github.com/thkukuk/wtmpdb) instead.
* Deprecated _pam_overwrite(), _pam_overwrite_n(), and _pam_drop_reply() macros
provided by _pam_macros.h; the memory override performed by these macros can
be optimized out by the compiler and therefore can no longer be relied upon.
Multiple minor bug fixes, portability fixes, documentation improvements,
and translation updates.
