### PR TITLE
v1.6.0, revision 2

### DIFF
--- a/include/_pam_macros.h
+++ b/include/_pam_macros.h
@@ -49,7 +49,7 @@ do {                 \
 } while (0)
 
 /*
- * WARNING: Do NOT use this macro, as it does not reliable override the memory.
+ * WARNING: Do NOT use this macro, as it does not reliably override the memory.
  */
 
 #define _pam_drop_reply(/* struct pam_response * */ reply, /* int */ replies) \


### PR DESCRIPTION
* treewide: fix typos in comments

upstream commit id: <94c798c2d82a3df4d1e98e0a6855d92a5a4b1450>